### PR TITLE
Added step to configure `example.config` to `bin/config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ __b__(aeck's implementation of i) __3__ (wm for Windows)
 
 1. Head over to the [Release](https://github.com/ritschmaster/b3/releases) page and download the latest binary zip file.
 2. Decompress it somwhere
-3. Execute `b3.exe`
+3. Copy the `example.config` to `bin` (See [FAQ](#faq) if you want to personalize the configuration))
+4. Execute `b3.exe`
 
 ### Using source code releases
 
 1. Head over to the [Release](https://github.com/ritschmaster/b3/releases) page and download the latest source zip file.
 2. Decompress it somwhere
 3. See [Compiling](#Compiling)
-4. Execute `b3.exe`
+4. Copy the `example.config` to `bin` (See [FAQ](#faq) if you want to personalize the configuration))
+5. Execute `b3.exe`
 
 ## FAQ
 


### PR DESCRIPTION
Tried to ease up the kickstart section. I ran into the problem following the instruction but nothing happend when I clicked on `b3.exe`.
After thinking and searching, I found the missing step that a configuration needs to be available in the same path of the `b3.exe`.
I am hoping that with this added step, the start and the usage of b3 will be increased.

As written in the [issue/5](https://github.com/ritschmaster/b3/issues/5), this is the pull request.